### PR TITLE
feat(configs): Add prod config to handle dev and prod CAPI urls

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+#setuptools_scm
+src/cscapi/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel"
+    "wheel",
+    "setuptools_scm",
 ]
 build-backend = "setuptools.build_meta"
+[tool.setuptools_scm]
+write_to = "src/cscapi/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ python_requires = >=3.9
 install_requires =
     sqlalchemy
     python-dateutil
-    httpx==0.25.1
+    httpx==0.26.*
     dacite
     importlib-metadata
     pyjwt

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,4 @@ import setuptools
 if __name__ == "__main__":
     setuptools.setup(
         use_scm_version=True,
-        setup_requires=["setuptools_scm"],
     )

--- a/src/cscapi/client.py
+++ b/src/cscapi/client.py
@@ -48,9 +48,9 @@ def has_valid_token(machine: MachineModel, latency_offset=10) -> bool:
 class CAPIClientConfig:
     scenarios: List[str]
     prod: bool = False
+    user_agent_prefix: str = ""
     max_retries: int = 3
     latency_offset: int = 10
-    user_agent_prefix: str = ""
     retry_delay: int = 5
 
 

--- a/src/cscapi/client.py
+++ b/src/cscapi/client.py
@@ -166,7 +166,9 @@ class CAPIClient:
         for signal_batch in batched(signals, 250):
             body = [asdict(signal) for signal in signal_batch]
             resp = self.http_client.post(
-                self._get_url(CAPI_SIGNALS_ENDPOINT), json=body, headers={"Authorization": token}
+                self._get_url(CAPI_SIGNALS_ENDPOINT),
+                json=body,
+                headers={"Authorization": token},
             )
             resp.raise_for_status()
             self._mark_signals_as_sent(signal_batch)
@@ -274,7 +276,8 @@ class CAPIClient:
             MachineModel(machine_id=main_machine_id, scenarios=scenarios)
         )
         resp = self.http_client.get(
-            self._get_url(CAPI_DECISIONS_ENDPOINT), headers={"Authorization": machine.token}
+            self._get_url(CAPI_DECISIONS_ENDPOINT),
+            headers={"Authorization": machine.token},
         )
 
         return resp.json()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -134,16 +134,18 @@ def prod_client(storage):
 
 
 class TestChooseEnv:
-    def test_handle_dev_url(
-        self, client: CAPIClient, httpx_mock: HTTPXMock
-    ):
+    def test_handle_dev_url(self, client: CAPIClient, httpx_mock: HTTPXMock):
         assert client.url == CAPI_BASE_DEV_URL
 
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": dummy_token()}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": dummy_token()},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -157,16 +159,18 @@ class TestChooseEnv:
 
         assert requests[0].url == CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT
 
-    def test_handle_prod_url(
-        self, prod_client: CAPIClient, httpx_mock: HTTPXMock
-    ):
+    def test_handle_prod_url(self, prod_client: CAPIClient, httpx_mock: HTTPXMock):
         assert prod_client.url == CAPI_BASE_URL
 
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": dummy_token()}
+            method="POST",
+            url=CAPI_BASE_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": dummy_token()},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -186,13 +190,21 @@ class TestSendSignals:
         assert len(client.storage.get_all_signals()) == 0
         token = dummy_token()
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": token}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": token},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
-        httpx_mock.add_response(method="POST", url=CAPI_BASE_DEV_URL + CAPI_SIGNALS_ENDPOINT, text="OK")
-        httpx_mock.add_response(method="POST", url=CAPI_BASE_DEV_URL + CAPI_METRICS_ENDPOINT, text="OK")
+        httpx_mock.add_response(
+            method="POST", url=CAPI_BASE_DEV_URL + CAPI_SIGNALS_ENDPOINT, text="OK"
+        )
+        httpx_mock.add_response(
+            method="POST", url=CAPI_BASE_DEV_URL + CAPI_METRICS_ENDPOINT, text="OK"
+        )
 
         s1 = replace(mock_signals()[0], scenario="crowdsecurity/http-bf")
         s2 = mock_signals()[0]
@@ -230,13 +242,21 @@ class TestSendSignals:
         assert len(client.storage.get_all_signals()) == 0
         token = dummy_token()
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": token}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": token},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
-        httpx_mock.add_response(method="POST", url=CAPI_BASE_DEV_URL + CAPI_SIGNALS_ENDPOINT, text="OK")
-        httpx_mock.add_response(method="POST", url=CAPI_BASE_DEV_URL + CAPI_METRICS_ENDPOINT, text="OK")
+        httpx_mock.add_response(
+            method="POST", url=CAPI_BASE_DEV_URL + CAPI_SIGNALS_ENDPOINT, text="OK"
+        )
+        httpx_mock.add_response(
+            method="POST", url=CAPI_BASE_DEV_URL + CAPI_METRICS_ENDPOINT, text="OK"
+        )
 
         s1 = mock_signals()[0]
         client.add_signals([s1])
@@ -248,13 +268,21 @@ class TestSendSignals:
         self, httpx_mock: HTTPXMock, client: CAPIClient
     ):
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": dummy_token()}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": dummy_token()},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
-        httpx_mock.add_response(method="POST", url=CAPI_BASE_DEV_URL + CAPI_SIGNALS_ENDPOINT, text="OK")
-        httpx_mock.add_response(method="POST", url=CAPI_BASE_DEV_URL + CAPI_METRICS_ENDPOINT, text="OK")
+        httpx_mock.add_response(
+            method="POST", url=CAPI_BASE_DEV_URL + CAPI_SIGNALS_ENDPOINT, text="OK"
+        )
+        httpx_mock.add_response(
+            method="POST", url=CAPI_BASE_DEV_URL + CAPI_METRICS_ENDPOINT, text="OK"
+        )
 
         assert client.storage.get_machine_by_id("test") is None
 
@@ -292,13 +320,21 @@ class TestSendSignals:
     ):
         token = dummy_token(exp=int(time.time()) - 3600)
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": token}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": token},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
-        httpx_mock.add_response(method="POST", url=CAPI_BASE_DEV_URL + CAPI_SIGNALS_ENDPOINT, text="OK")
-        httpx_mock.add_response(method="POST", url=CAPI_BASE_DEV_URL + CAPI_METRICS_ENDPOINT, text="OK")
+        httpx_mock.add_response(
+            method="POST", url=CAPI_BASE_DEV_URL + CAPI_SIGNALS_ENDPOINT, text="OK"
+        )
+        httpx_mock.add_response(
+            method="POST", url=CAPI_BASE_DEV_URL + CAPI_METRICS_ENDPOINT, text="OK"
+        )
 
         assert client.storage.get_machine_by_id("test") is None
 
@@ -404,10 +440,15 @@ class TestSendSignals:
     def test_signals_with_retry(self, httpx_mock: HTTPXMock, client: CAPIClient):
         stale_token = dummy_token(exp=int(time.time()) - 3600)
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": stale_token}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": stale_token},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_SIGNALS_ENDPOINT, text="OK", status_code=401
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_SIGNALS_ENDPOINT,
+            text="OK",
+            status_code=401,
         )
         machine = MachineModel(
             machine_id="test",
@@ -426,10 +467,14 @@ class TestGetDecisions:
         self, httpx_mock: HTTPXMock, client: CAPIClient
     ):
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": dummy_token()}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": dummy_token()},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -458,10 +503,14 @@ class TestGetDecisions:
         self, httpx_mock: HTTPXMock, client: CAPIClient
     ):
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": dummy_token()}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": dummy_token()},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -489,7 +538,9 @@ class TestGetDecisions:
             json={"token": dummy_token(exp=int(time.time()) - 3600)},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
         httpx_mock.add_response(
             method="GET",
@@ -514,13 +565,19 @@ class TestEnroll:
         self, httpx_mock: HTTPXMock, client: CAPIClient
     ):
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": dummy_token()}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": dummy_token()},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_ENROLL_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_ENROLL_ENDPOINT,
+            json={"message": "OK"},
         )
 
         assert client.storage.get_machine_by_id("test") is None
@@ -545,13 +602,19 @@ class TestEnroll:
         self, httpx_mock: HTTPXMock, client: CAPIClient
     ):
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT, json={"token": dummy_token()}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_LOGIN_ENDPOINT,
+            json={"token": dummy_token()},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_ENROLL_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_ENROLL_ENDPOINT,
+            json={"message": "OK"},
         )
 
         assert client.storage.get_machine_by_id("test") is None
@@ -577,10 +640,14 @@ class TestEnroll:
             json={"token": dummy_token(exp=int(time.time()) - 3600)},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_WATCHER_REGISTER_ENDPOINT,
+            json={"message": "OK"},
         )
         httpx_mock.add_response(
-            method="POST", url=CAPI_BASE_DEV_URL + CAPI_ENROLL_ENDPOINT, json={"message": "OK"}
+            method="POST",
+            url=CAPI_BASE_DEV_URL + CAPI_ENROLL_ENDPOINT,
+            json={"message": "OK"},
         )
 
         assert client.storage.get_machine_by_id("test") is None


### PR DESCRIPTION
Fixes #2 

It seems it is not possible to have a param with default value before a param without default value (@see https://stackoverflow.com/questions/73535664/why-can-t-fields-with-default-values-come-first for example).

That's why I set the `prod` param after the `scenarios` param.