### PR TITLE
feat(sql storage): [BREAKING CHANGES] : Fix "prune signals after sent" feature and modify database structure

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -21,10 +21,22 @@ signals = [
         context=[{"key": "scenario-version", "value": "1.0.0"}],
         message="test message to see where it is written",
         decisions=[
-            {"origin": "crowdsec", "duration": "1h", "scenario": "crowdsec/ssh-bf", "scope": "ip", "type": "ban",
-             "value": "81.81.81.81"},
-            {"origin": "pysdk", "duration": "2h", "scenario": "crowdsec/ssh-bf", "scope": "ip", "type": "ban",
-             "value": "81.81.81.81"},
+            {
+                "origin": "crowdsec",
+                "duration": "1h",
+                "scenario": "crowdsec/ssh-bf",
+                "scope": "ip",
+                "type": "ban",
+                "value": "81.81.81.81",
+            },
+            {
+                "origin": "pysdk",
+                "duration": "2h",
+                "scenario": "crowdsec/ssh-bf",
+                "scope": "ip",
+                "type": "ban",
+                "value": "81.81.81.81",
+            },
         ],
     )
 ]

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -20,6 +20,12 @@ signals = [
         machine_id=generate_machine_id_from_key("myMachineKeyIdentifier"),
         context=[{"key": "scenario-version", "value": "1.0.0"}],
         message="test message to see where it is written",
+        decisions=[
+            {"origin": "crowdsec", "duration": "1h", "scenario": "crowdsec/ssh-bf", "scope": "ip", "type": "ban",
+             "value": "81.81.81.81"},
+            {"origin": "pysdk", "duration": "2h", "scenario": "crowdsec/ssh-bf", "scope": "ip", "type": "ban",
+             "value": "81.81.81.81"},
+        ],
     )
 ]
 

--- a/src/cscapi/sql_storage.py
+++ b/src/cscapi/sql_storage.py
@@ -12,7 +12,7 @@ from sqlalchemy import (
     create_engine,
     delete,
     update,
-    event
+    event,
 )
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -26,10 +26,10 @@ from sqlalchemy.engine import Engine
 from cscapi import storage
 
 
-'''
+"""
 By default, foreign key constraints are disabled in SQLite.
 @see https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#foreign-key-support
-'''
+"""
 
 
 @event.listens_for(Engine, "connect")
@@ -86,7 +86,9 @@ class SourceDBModel(Base):
     value = Column(TEXT)
     as_name = Column(TEXT)
     longitude = Column(Float)
-    signal_id = Column(Integer, ForeignKey("signal_models.alert_id", ondelete="CASCADE"))
+    signal_id = Column(
+        Integer, ForeignKey("signal_models.alert_id", ondelete="CASCADE")
+    )
 
 
 class ContextDBModel(Base):


### PR DESCRIPTION
- [BREAKING CHANGE]: Add signal_id foreign key in source_models table
- [BREAKING CHANGE]: Remove source_id foreign key in signal_models table

- Use delete on cascade for source, context, and decisions signal_id foreign key
- Enable foreign key constraint check for sqlite