### PR TITLE
Enable foreign key constraints only in SQLite connections

### DIFF
--- a/src/cscapi/sql_storage.py
+++ b/src/cscapi/sql_storage.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import (
 )
 
 from sqlalchemy.engine import Engine
+from sqlite3 import Connection as SQLiteConnection
 from cscapi import storage
 
 
@@ -34,9 +35,10 @@ By default, foreign key constraints are disabled in SQLite.
 
 @event.listens_for(Engine, "connect")
 def set_sqlite_pragma(dbapi_connection, connection_record):
-    cursor = dbapi_connection.cursor()
-    cursor.execute("PRAGMA foreign_keys=ON")
-    cursor.close()
+    if isinstance(dbapi_connection, SQLiteConnection):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
 
 
 class Base(DeclarativeBase):


### PR DESCRIPTION
## Description
This PR addresses compatibility concerns with SQLite connections by ensuring that the PRAGMA command is executed exclusively for SQLite databases. Without this fix, executing the PRAGMA command indiscriminately poses compatibility issues with MariaDB and MySQL.

## Changes Made
### Modified Files
- **src/cscapi/sql_storage.py**: Modified the `set_sqlite_pragma` function to include a conditional check, ensuring that the PRAGMA command is executed only for SQLite connections.